### PR TITLE
Run tests that access objects in another schema

### DIFF
--- a/spec/database.yml
+++ b/spec/database.yml
@@ -1,6 +1,6 @@
 default:
-  username: ruby
-  password: ruby
+  username: system
+  password: oracle
   database: xe
   host: localhost
   port: 49161

--- a/spec/function_spec.rb
+++ b/spec/function_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 RSpec.describe 'Functions' do
   describe '#betwnstr' do
     it 'returns a substring based on the indexes provided' do
-      expect(plsql.betwnstr('Test', 2, 3)).to eq 'es'
+      expect(plsql.ruby.betwnstr('Test', 2, 3)).to eq 'es'
     end
   end
 end

--- a/spec/remove_rooms_by_name_spec.rb
+++ b/spec/remove_rooms_by_name_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 
 describe "Remove rooms by name" do
   before(:all) do
-    plsql.rooms.insert_values(
+    plsql.ruby.rooms.insert_values(
       [:room_key, :name],
       [1, 'Dining Room'],
       [2, 'Living Room'],
@@ -12,7 +12,7 @@ describe "Remove rooms by name" do
       [4, 'Bathroom'],
       [5, 'Bedroom']
     )
-    plsql.room_contents.insert_values(
+    plsql.ruby.room_contents.insert_values(
       [:contents_key, :room_key, :name],
       [1, 1, 'Table'],
       [2, 1, 'Hutch'],
@@ -27,24 +27,24 @@ describe "Remove rooms by name" do
   end
 
   it "should remove a room without furniture" do
-    rooms_without_b = plsql.rooms.all("WHERE name NOT LIKE 'B%'")
-    plsql.remove_rooms_by_name('B%')
-    expect(plsql.rooms.all).to eq rooms_without_b
+    rooms_without_b = plsql.ruby.rooms.all("WHERE name NOT LIKE 'B%'")
+    plsql.ruby.remove_rooms_by_name('B%')
+    expect(plsql.ruby.rooms.all).to eq rooms_without_b
   end
 
   it "should not remove a room with furniture" do
     expect {
       expect {
-        plsql.remove_rooms_by_name('Living Room')
+        plsql.ruby.remove_rooms_by_name('Living Room')
       }.to raise_error(/ORA-02292/)
-    }.not_to change { plsql.rooms.all }
+    }.not_to change { plsql.ruby.rooms.all }
   end
 
   it "should raise exception when NULL value passed" do
     expect {
       expect {
-        plsql.remove_rooms_by_name(NULL)
+        plsql.ruby.remove_rooms_by_name(NULL)
       }.to raise_error(/program error/)
-    }.not_to change { plsql.rooms.all }
+    }.not_to change { plsql.ruby.rooms.all }
   end
 end


### PR DESCRIPTION
If I connect as one user, and access resources created in another schema, then:

- `function_spec.rb` works fine
- `remove_rooms_by_name_spec.rb` hangs on the first `insert_values` call

I haven't figured out why.

If we can get this to work, then we could create and drop a schema as part of the test setup. We need *some* way of automatically bringing a fresh database to a known state. We're currently using `docker-entrypoint-initdb.d` for this, but it's really annoying to rebuild the docker container when something was wrong with the source code, rather than just rerunning the tests. Something like Flyway would be another option that we could run outside of the docker container.

The ruby-plsql-rspec examples manage the stored procedures they are testing, and they run them in with "create or replace". "create or replace" doesn't work with tables in oracle.